### PR TITLE
Tomsci trackpad

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -103,7 +103,7 @@ void GraphicsWindow::MouseMoved(double x, double y, bool leftDown,
         shiftDown = !shiftDown;
     }
 
-    if(SS.showToolbar) {
+    if(SS.showToolbar && !rightDown) {
         if(ToolbarMouseMoved((int)x, (int)y)) {
             hover.Clear();
             return;
@@ -494,7 +494,8 @@ void GraphicsWindow::ReplacePending(hRequest before, hRequest after) {
 
 void GraphicsWindow::MouseMiddleOrRightDown(double x, double y) {
     if(window->IsEditorVisible()) return;
-
+    // When right-clicking, hide any toolbar tooltips
+    ToolbarMouseMoved((int)-1, (int)-1);
     orig.offset = offset;
     orig.projUp = projUp;
     orig.projRight = projRight;


### PR DESCRIPTION
looks like I based this on an old version of your branch? anyways, I added some code that hides the tooltip when right mouse button is down, It's probably not the best code, but it seems to work.

I also noticed there is already this code in `MouseRightUp`:

```cpp
    // Don't show a context menu if the user is right-clicking the toolbar,
    // or if they are finishing a pan.
    if(ToolbarMouseMoved((int)x, (int)y)) return;
```

Which I find strange because it only happens at mouse >UP<.

I instead disabled the hit test code for the toolbar while moving the mouse, and when right-clicking on the toolbar I turn off the annotation (using `ToolbarMouseMoved((int)-1, (int)-1);`, note the negative coords).

Hope this helps, really like your PR and hope we can merge it soon!